### PR TITLE
✨ main宛のpullrequestがmergeされたときに自動でデプロイするアクションを作成

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  create-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup NodeJS Environment 18
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Build and Daploy
+        run: |
+          git config --local user.name github-actions[bot]
+          git config --local user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git pull
+          yarn install
+          yarn build
+          yarn deploy


### PR DESCRIPTION
# main宛のpullrequestがmergeされたときに自動でデプロイする

自動で以下のビルドの操作を実行するようにしました
```
yarn build
yarn deploy
```
トリガーの条件はmain宛のpullrequestがmergeされたときに加え、手動実行も可能です


gitのuserは慣例に基づき github-actions[bot] としました