### PR TITLE
インストーラー名称変更に対応

### DIFF
--- a/src/components/HOME/DownloadBtn.vue
+++ b/src/components/HOME/DownloadBtn.vue
@@ -10,9 +10,9 @@ const prop = defineProps<Prop>();
 function getFileName() {
   switch (prop.osName) {
     case 'windows':
-      return `ServerStarter2.${prop.version}.msi`
+      return `ServerStarter-v${prop.version}.msi`
     case 'mac':
-      return `ServerStarter2-${prop.version}.pkg`
+      return `ServerStarter-v${prop.version}.pkg`
     case 'linux':
       return ''
     default:


### PR DESCRIPTION
# 概要

ServerStarter2のインストーラーの名称が`ServerStarter-v0.0.0.msi`の形式に統一されたため，ダウンロード時のファイル名をこれに対応